### PR TITLE
Turn off hand pose canvas

### DIFF
--- a/client/src/pages/Prediction/Gestures/thumbsDown.js
+++ b/client/src/pages/Prediction/Gestures/thumbsDown.js
@@ -1,3 +1,4 @@
+import { erf } from "@tensorflow/tfjs";
 import * as fp from "fingerpose";
 
 const thumbsDownGesture = new fp.GestureDescription('thumbs_down');

--- a/client/src/pages/Prediction/Gestures/thumbsUp.js
+++ b/client/src/pages/Prediction/Gestures/thumbsUp.js
@@ -1,3 +1,4 @@
+import { erf } from "@tensorflow/tfjs";
 import * as fp from "fingerpose";
 
 const thumbsUpGesture = new fp.GestureDescription('thumbs_up');

--- a/client/src/pages/Prediction/index.js
+++ b/client/src/pages/Prediction/index.js
@@ -44,7 +44,7 @@ function Prediction() {
       //loop and detect hands
       setInterval(() => {
         detectHands(handNet);
-      }, 1000);
+      }, 250);
     }
 
     const detectHands = async (handNet) => {
@@ -73,9 +73,6 @@ function Prediction() {
 
         // Gesture detections
         if(hands.length > 0){
-
-
-
           const gesture = await GE.estimate(hands[0].landmarks,8);
 
           if(gesture.gestures !== undefined && gesture.gestures.length>0) {
@@ -89,9 +86,11 @@ function Prediction() {
           }
         }
 
-        //draw mesh
-        const ctx = canvasRef.current.getContext("2d");
-        drawHands(hands, ctx);
+        // draw mesh (uncomment this section to draw vectors over the hand)
+        // This will help ensure tensor flow is detecting the hand correctly
+        // Uses the draw.js in the utils foler
+          // const ctx = canvasRef.current.getContext("2d");
+          // drawHands(hands, ctx);
       }
     };
 


### PR DESCRIPTION
commented out canvas generation for hand pose detection to speed up UI and remove the hand overlay on the video